### PR TITLE
feat(sign): Ed25519 signatures (portable, JVM<->Node interop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,17 @@ API, native on each platform.
 
 ## v2 status
 
-The synchronous foundation is landed and verified on JVM and Node against
-NIST/RFC test vectors; the asymmetric + AEAD tier is in progress.
+The synchronous foundation, AES-256-GCM (AEAD), and Ed25519 signatures are
+landed and verified on JVM and Node against NIST/RFC vectors and JVM↔Node
+interop KATs; X25519 key agreement is the remaining tier.
 
 | namespace | provides | sync? | status |
 |---|---|---|---|
 | `…geheimnis.core`  | `random-bytes` (CSPRNG), `ct-equal?` | sync | ✅ |
 | `…geheimnis.codec` | base64url / hex / utf8, byte-array utils | sync | ✅ |
 | `…geheimnis.hash`  | `hmac-sha256`, `hkdf`; `sha256`/`sha512` (via hasch) | sync | ✅ |
-| `…geheimnis.aead`  | AES-256-GCM authenticated encryption | async | ⏳ |
-| `…geheimnis.sign`  | Ed25519 sign / verify | async | ⏳ |
+| `…geheimnis.aead`  | AES-256-GCM authenticated encryption | async | ✅ |
+| `…geheimnis.sign`  | Ed25519 sign / verify | async | ✅ |
 | `…geheimnis.dh`    | X25519 key agreement | async | ⏳ |
 
 **Design principle — sync where possible, async only where forced.** Hashing,

--- a/src/org/replikativ/geheimnis/sign.cljc
+++ b/src/org/replikativ/geheimnis/sign.cljc
@@ -1,0 +1,141 @@
+(ns org.replikativ.geheimnis.sign
+  "Ed25519 digital signatures — asymmetric authentication. A signer holds a
+   private key; anyone with the matching public key can verify, with no shared
+   secret. This is the primitive for peer-to-peer identity: peer A signs an
+   assertion, peer B (browser, Node, or JVM) verifies it against A's public key.
+
+   ASYNC: every op returns a core.async channel, exactly like `aead` — Web Crypto
+   on ClojureScript is Promise-based, and the JVM resolves synchronously into the
+   channel, so callers get one uniform contract on both platforms. `sign`/keygen
+   yield byte-arrays; `verify` yields a boolean (or an ExceptionInfo on the
+   channel if the key/signature is malformed).
+
+   KEYS ARE RAW: a public key is 32 bytes, a private key is the 32-byte seed, a
+   signature is 64 bytes — the encodings every Ed25519 implementation agrees on.
+   Internally we wrap raw keys in the standard PKCS#8 / SPKI DER envelopes so the
+   same bytes move between java.security and Web Crypto unchanged; a JVM-signed
+   message verifies on a CLJS peer and vice versa (see sign-test's interop KAT).
+
+   Platform note: Ed25519 in Web Crypto is available in Node 18+ and current
+   browsers (2026). Very old browsers without it will surface an error on the
+   channel; a `@noble/curves` fallback for that case is future work."
+  (:require [clojure.core.async :as a]
+            [org.replikativ.geheimnis.codec :as codec])
+  #?(:clj (:import [java.security KeyPairGenerator KeyFactory Signature]
+                   [java.security.spec PKCS8EncodedKeySpec X509EncodedKeySpec])))
+
+;; Fixed DER envelopes for a raw Ed25519 seed / public key. The algorithm OID is
+;; 1.3.101.112; the only variable part is the trailing 32 raw bytes, so these
+;; constant prefixes are all we need to move between raw and PKCS8/SPKI.
+(def ^:private pkcs8-prefix (codec/hex->bytes "302e020100300506032b657004220420"))
+(def ^:private spki-prefix  (codec/hex->bytes "302a300506032b6570032100"))
+
+(defn- seed->pkcs8 [seed] (codec/concat-bytes [pkcs8-prefix seed]))
+(defn- pub->spki [pub] (codec/concat-bytes [spki-prefix pub]))
+
+(defn- der->raw
+  "Last 32 bytes of a PKCS8/SPKI DER encoding — the raw key material."
+  [der]
+  (let [n (codec/blen der)]
+    #?(:clj  (java.util.Arrays/copyOfRange ^bytes der (- n 32) n)
+       :cljs (.slice der (- n 32)))))
+
+#?(:clj
+   (defn- jvm->chan [f]
+     (let [ch (a/chan 1)]
+       (try (a/put! ch (f)) (catch Throwable e (a/put! ch e)))
+       (a/close! ch)
+       ch)))
+
+#?(:cljs
+   (defn- subtle []
+     (or (some-> (when (exists? js/crypto) js/crypto) .-subtle)
+         (some-> (when (exists? js/globalThis) (.-crypto js/globalThis)) .-subtle)
+         (throw (ex-info "No Web Crypto (crypto.subtle) available for Ed25519" {})))))
+
+#?(:cljs
+   (defn- bytes<-chan
+     "Bridge a Promise<ArrayBuffer> to a channel of Uint8Array (error -> ex-info)."
+     [p]
+     (let [ch (a/chan 1)]
+       (.then p
+              (fn [buf] (a/put! ch (js/Uint8Array. buf)) (a/close! ch))
+              (fn [err] (a/put! ch (ex-info "Ed25519 operation failed" {:error err})) (a/close! ch)))
+       ch)))
+
+#?(:clj
+   (defn- jvm-generate []
+     (let [kp (.generateKeyPair (KeyPairGenerator/getInstance "Ed25519"))]
+       {:public  (der->raw (.getEncoded (.getPublic kp)))
+        :private (der->raw (.getEncoded (.getPrivate kp)))})))
+
+#?(:clj
+   (defn- jvm-priv [seed]
+     (.generatePrivate (KeyFactory/getInstance "Ed25519")
+                       (PKCS8EncodedKeySpec. (seed->pkcs8 seed)))))
+
+#?(:clj
+   (defn- jvm-pub [pub]
+     (.generatePublic (KeyFactory/getInstance "Ed25519")
+                      (X509EncodedKeySpec. (pub->spki pub)))))
+
+#?(:clj
+   (defn- jvm-sign [seed msg]
+     (let [s (Signature/getInstance "Ed25519")]
+       (.initSign s (jvm-priv seed)) (.update s ^bytes msg) (.sign s))))
+
+#?(:clj
+   (defn- jvm-verify [pub msg sig]
+     (let [s (Signature/getInstance "Ed25519")]
+       (.initVerify s (jvm-pub pub)) (.update s ^bytes msg) (.verify s ^bytes sig))))
+
+#?(:cljs
+   (defn- cljs-generate []
+     (let [ch (a/chan 1)]
+       (-> (.generateKey (subtle) #js {:name "Ed25519"} true #js ["sign" "verify"])
+           (.then (fn [kp]
+                    (js/Promise.all #js [(.exportKey (subtle) "spki" (.-publicKey kp))
+                                         (.exportKey (subtle) "pkcs8" (.-privateKey kp))])))
+           (.then (fn [arr]
+                    (a/put! ch {:public  (der->raw (js/Uint8Array. (aget arr 0)))
+                                :private (der->raw (js/Uint8Array. (aget arr 1)))})
+                    (a/close! ch))
+                  (fn [err] (a/put! ch (ex-info "Ed25519 keygen failed" {:error err})) (a/close! ch))))
+       ch)))
+
+#?(:cljs
+   (defn- cljs-sign [seed msg]
+     (bytes<-chan
+      (-> (.importKey (subtle) "pkcs8" (seed->pkcs8 seed) #js {:name "Ed25519"} false #js ["sign"])
+          (.then (fn [k] (.sign (subtle) #js {:name "Ed25519"} k msg)))))))
+
+#?(:cljs
+   (defn- cljs-verify [pub msg sig]
+     (let [ch (a/chan 1)]
+       (-> (.importKey (subtle) "spki" (pub->spki pub) #js {:name "Ed25519"} false #js ["verify"])
+           (.then (fn [k] (.verify (subtle) #js {:name "Ed25519"} k sig msg)))
+           (.then (fn [ok?] (a/put! ch (boolean ok?)) (a/close! ch))
+                  (fn [err] (a/put! ch (ex-info "Ed25519 verify failed" {:error err})) (a/close! ch))))
+       ch)))
+
+(defn generate-keypair
+  "Generate a fresh Ed25519 keypair. -> channel of {:public <32 bytes>
+   :private <32-byte seed>}."
+  []
+  #?(:clj (jvm->chan jvm-generate) :cljs (cljs-generate)))
+
+(defn sign
+  "Sign `message` (bytes) with a 32-byte Ed25519 `private-key` seed.
+   -> channel of the 64-byte signature. Ed25519 is deterministic: the same
+   (seed, message) always yields the same signature on every platform."
+  [private-key message]
+  #?(:clj  (jvm->chan #(jvm-sign private-key message))
+     :cljs (cljs-sign private-key message)))
+
+(defn verify
+  "Verify `signature` over `message` (bytes) against a 32-byte Ed25519
+   `public-key`. -> channel of true/false, or an ExceptionInfo on the channel if
+   the key or signature is malformed."
+  [public-key message signature]
+  #?(:clj  (jvm->chan #(jvm-verify public-key message signature))
+     :cljs (cljs-verify public-key message signature)))

--- a/test/org/replikativ/geheimnis/sign_test.cljc
+++ b/test/org/replikativ/geheimnis/sign_test.cljc
@@ -1,0 +1,73 @@
+(ns org.replikativ.geheimnis.sign-test
+  "Ed25519 sign/verify round-trip + a fixed interop KAT. The KAT was produced on
+   the JVM; a ClojureScript peer that reproduces the SAME signature from the seed
+   and verifies the SAME public key is byte-compatible — a JVM-signed assertion
+   verifies on a browser/Node peer and vice versa. Both platforms use their
+   native Ed25519 (java.security / Web Crypto), so agreement here is a strong
+   correctness anchor, not just self-consistency."
+  (:require #?(:clj [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer-macros [deftest is testing async]])
+            [clojure.core.async :as a]
+            [org.replikativ.geheimnis.sign :as sign]
+            [org.replikativ.geheimnis.codec :as codec]))
+
+(def ^:private kat-seed "99c1cc652f850ae2da7f4e078aa9acfc2ff67c3fdcb19bd89d25c3c0f87ec3ed")
+(def ^:private kat-pub  "a44f96b0986462dfa7ec2239d00622ff8398efd8388a8efdadfb7ba802b7c62a")
+(def ^:private kat-msg  "geheimnis-ed25519-kat")
+(def ^:private kat-sig  "7678fd1b3a9c9ffc977ed5296f825a05b03b59836e35384c4bf8b02005f687eb807643cfc993cedcd44bca3da8bdc0e97126c6fe82ce9268fa1146e192f0b50e")
+
+(defn- sig-hex [r]
+  (if #?(:clj (bytes? r) :cljs (instance? js/Uint8Array r))
+    (codec/bytes->hex r)
+    ::error))
+
+(defn- flip-first [bs]
+  #?(:clj  (let [c (java.util.Arrays/copyOf ^bytes bs (alength ^bytes bs))]
+             (aset c 0 (unchecked-byte (bit-xor (aget c 0) 1))) c)
+     :cljs (let [c (.slice bs 0)] (aset c 0 (bit-xor (aget c 0) 1)) c)))
+
+(deftest ed25519-interop-kat
+  (let [seed (codec/hex->bytes kat-seed)
+        pub  (codec/hex->bytes kat-pub)
+        msg  (codec/str->bytes kat-msg)
+        sig  (codec/hex->bytes kat-sig)]
+    #?(:clj
+       (do
+         (is (= kat-sig (sig-hex (a/<!! (sign/sign seed msg)))) "sign(seed,msg) -> fixed sig (deterministic)")
+         (is (true? (a/<!! (sign/verify pub msg sig))) "verify(pub,msg,sig)")
+         (is (false? (a/<!! (sign/verify pub (codec/str->bytes "tampered") sig))) "wrong message rejected")
+         (is (false? (a/<!! (sign/verify pub msg (flip-first sig)))) "tampered signature rejected"))
+       :cljs
+       (async
+        done
+        (a/go
+          (is (= kat-sig (sig-hex (a/<! (sign/sign seed msg)))) "sign(seed,msg) -> fixed sig (deterministic)")
+          (is (true? (a/<! (sign/verify pub msg sig))) "verify(pub,msg,sig)")
+          (is (false? (a/<! (sign/verify pub (codec/str->bytes "tampered") sig))) "wrong message rejected")
+          (is (false? (a/<! (sign/verify pub msg (flip-first sig)))) "tampered signature rejected")
+          (done))))))
+
+(deftest ed25519-roundtrip
+  #?(:clj
+     (let [{:keys [public private]} (a/<!! (sign/generate-keypair))
+           other (:public (a/<!! (sign/generate-keypair)))
+           msg (codec/str->bytes "hello geheimnis ed25519 🔏")
+           sig (a/<!! (sign/sign private msg))]
+       (testing "verify(sign(x)) = true"
+         (is (true? (a/<!! (sign/verify public msg sig)))))
+       (testing "a different (valid) public key rejects the signature"
+         (is (false? (a/<!! (sign/verify other msg sig)))))
+       (testing "a tampered message is rejected"
+         (is (false? (a/<!! (sign/verify public (codec/str->bytes "hello geheimnis ed25519 🔓") sig))))))
+     :cljs
+     (async
+      done
+      (a/go
+        (let [{:keys [public private]} (a/<! (sign/generate-keypair))
+              other (:public (a/<! (sign/generate-keypair)))
+              msg (codec/str->bytes "hello geheimnis ed25519 🔏")
+              sig (a/<! (sign/sign private msg))]
+          (is (true? (a/<! (sign/verify public msg sig))) "round-trip")
+          (is (false? (a/<! (sign/verify other msg sig))) "wrong key")
+          (is (false? (a/<! (sign/verify public (codec/str->bytes "hello geheimnis ed25519 🔓") sig))) "tamper")
+          (done))))))

--- a/tests.edn
+++ b/tests.edn
@@ -1,0 +1,8 @@
+#kaocha/v1
+;; Scope the JVM suite to the v2 crypto namespaces (org.replikativ.geheimnis.*).
+;; The legacy v1 namespaces (geheimnis.{md5,aes,rsa,base64}) are deprecated and
+;; their tests are not maintained; the CLJS builds are already scoped the same
+;; way via ns-regexp in shadow-cljs.edn.
+{:tests [{:id          :unit
+          :test-paths  ["test"]
+          :ns-patterns ["org\\.replikativ\\.geheimnis\\..*-test$"]}]}


### PR DESCRIPTION
Adds `org.replikativ.geheimnis.sign` — Ed25519 digital signatures — the asymmetric-authentication primitive for peer-to-peer identity.

## Why
HS256 (shared secret) can't let peers verify *each other's* identity without pre-sharing a key. Ed25519 can: a signer holds a private key, and any peer — browser, Node, or JVM — verifies against the public key with no shared secret. This is the missing link for symmetric auth across peers.

## What
- **`sign` namespace**: `generate-keypair` / `sign` / `verify`, async on both platforms (uniform `core.async` channel contract, same shape as `aead`). JVM uses `java.security` Ed25519; CLJS uses Web Crypto (Node 18+, modern browsers).
- **Raw keys** (32-byte public, 32-byte seed, 64-byte signature), wrapped internally in the standard PKCS#8 / SPKI DER envelopes so the same bytes move between `java.security` and Web Crypto unchanged.
- **Interop KAT**: a signature captured on the JVM; Node reproduces the identical signature from the seed and verifies the JVM's public key — proving byte-level JVM↔Node interoperability (the DER wrapping is the only place this could break).
- **`tests.edn`**: scopes the JVM kaocha suite to the v2 `org.replikativ.geheimnis` namespaces, so JVM CI runs the real suite instead of the deprecated v1 tests (mirrors how the CLJS builds are already scoped by `ns-regexp`).

## Verified
JVM 12 tests / 29 assertions, Node 12 / 29, 0 failures.

## Follow-ups (not in this PR)
- `@noble/curves` fallback for very old browsers lacking Web Crypto Ed25519.
- `dh` (X25519) key agreement — the remaining v2 tier.
- EdDSA-JWT bridge in kabel (portable asymmetric token verify), which this unblocks.
