### PR TITLE
feat(dh): X25519 key agreement (portable, JVM<->Node interop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ API, native on each platform.
 
 ## v2 status
 
-The synchronous foundation, AES-256-GCM (AEAD), and Ed25519 signatures are
-landed and verified on JVM and Node against NIST/RFC vectors and JVM↔Node
-interop KATs; X25519 key agreement is the remaining tier.
+The full v2 surface — synchronous foundation, AES-256-GCM (AEAD), Ed25519
+signatures, and X25519 key agreement — is landed and verified on JVM and Node
+against NIST/RFC vectors and JVM↔Node interop KATs.
 
 | namespace | provides | sync? | status |
 |---|---|---|---|
@@ -35,7 +35,7 @@ interop KATs; X25519 key agreement is the remaining tier.
 | `…geheimnis.hash`  | `hmac-sha256`, `hkdf`; `sha256`/`sha512` (via hasch) | sync | ✅ |
 | `…geheimnis.aead`  | AES-256-GCM authenticated encryption | async | ✅ |
 | `…geheimnis.sign`  | Ed25519 sign / verify | async | ✅ |
-| `…geheimnis.dh`    | X25519 key agreement | async | ⏳ |
+| `…geheimnis.dh`    | X25519 key agreement | async | ✅ |
 
 **Design principle — sync where possible, async only where forced.** Hashing,
 HMAC and HKDF are synchronous on both platforms (`goog.crypt` / `java.security`),

--- a/src/org/replikativ/geheimnis/dh.cljc
+++ b/src/org/replikativ/geheimnis/dh.cljc
@@ -1,0 +1,119 @@
+(ns org.replikativ.geheimnis.dh
+  "X25519 Diffie-Hellman key agreement — the confidentiality counterpart to
+   `sign`. Two peers each hold a keypair; from opposite halves they compute the
+   SAME 32-byte shared secret, and nothing secret ever crosses the wire — only
+   public keys. This is how two peers (or a sender and a recipient) establish an
+   encryption key with no pre-shared secret, so a relay/server can carry
+   ciphertext it cannot read.
+
+   The raw shared secret is NOT used directly as a key — run it through
+   `hkdf` (org.replikativ.geheimnis.hash) to derive an AEAD key, then encrypt
+   with `aead`. dh establishes the key; hkdf shapes it; aead uses it.
+
+   ASYNC + RAW KEYS, exactly like `sign`: every op returns a core.async channel;
+   a public key is 32 bytes, a private key is the 32-byte scalar, and the shared
+   secret is 32 bytes. Internally we wrap raw keys in the standard PKCS#8 / SPKI
+   DER envelopes (X25519 OID 1.3.101.110) so the same bytes move between
+   java.security and Web Crypto unchanged — a JVM peer and a CLJS peer derive the
+   identical secret (see dh-test's interop KAT).
+
+   Platform note: X25519 in Web Crypto is available in Node 18+ and current
+   browsers; the JVM uses java.security KeyAgreement (JDK 11+)."
+  (:require [clojure.core.async :as a]
+            [org.replikativ.geheimnis.codec :as codec])
+  #?(:clj (:import [java.security KeyPairGenerator KeyFactory]
+                   [java.security.spec PKCS8EncodedKeySpec X509EncodedKeySpec]
+                   [javax.crypto KeyAgreement])))
+
+;; Fixed DER envelopes for a raw X25519 scalar / public key. Same structure as
+;; Ed25519 but with the X25519 algorithm OID (1.3.101.110 = ...2b656e), so the
+;; only difference from sign's prefixes is that trailing OID byte (6e vs 70).
+(def ^:private pkcs8-prefix (codec/hex->bytes "302e020100300506032b656e04220420"))
+(def ^:private spki-prefix  (codec/hex->bytes "302a300506032b656e032100"))
+
+(defn- scalar->pkcs8 [scalar] (codec/concat-bytes [pkcs8-prefix scalar]))
+(defn- pub->spki [pub] (codec/concat-bytes [spki-prefix pub]))
+
+(defn- der->raw
+  "Last 32 bytes of a PKCS8/SPKI DER encoding — the raw key material."
+  [der]
+  (let [n (codec/blen der)]
+    #?(:clj  (java.util.Arrays/copyOfRange ^bytes der (- n 32) n)
+       :cljs (.slice der (- n 32)))))
+
+#?(:clj
+   (defn- jvm->chan [f]
+     (let [ch (a/chan 1)]
+       (try (a/put! ch (f)) (catch Throwable e (a/put! ch e)))
+       (a/close! ch)
+       ch)))
+
+#?(:cljs
+   (defn- subtle []
+     (or (some-> (when (exists? js/crypto) js/crypto) .-subtle)
+         (some-> (when (exists? js/globalThis) (.-crypto js/globalThis)) .-subtle)
+         (throw (ex-info "No Web Crypto (crypto.subtle) available for X25519" {})))))
+
+#?(:clj
+   (defn- jvm-generate []
+     (let [kp (.generateKeyPair (KeyPairGenerator/getInstance "X25519"))]
+       {:public  (der->raw (.getEncoded (.getPublic kp)))
+        :private (der->raw (.getEncoded (.getPrivate kp)))})))
+
+#?(:clj
+   (defn- jvm-priv [scalar]
+     (.generatePrivate (KeyFactory/getInstance "X25519")
+                       (PKCS8EncodedKeySpec. (scalar->pkcs8 scalar)))))
+
+#?(:clj
+   (defn- jvm-pub [pub]
+     (.generatePublic (KeyFactory/getInstance "X25519")
+                      (X509EncodedKeySpec. (pub->spki pub)))))
+
+#?(:clj
+   (defn- jvm-agree [scalar pub]
+     (let [ka (KeyAgreement/getInstance "X25519")]
+       (.init ka (jvm-priv scalar))
+       (.doPhase ka (jvm-pub pub) true)
+       (.generateSecret ka))))
+
+#?(:cljs
+   (defn- cljs-generate []
+     (let [ch (a/chan 1)]
+       (-> (.generateKey (subtle) #js {:name "X25519"} true #js ["deriveBits"])
+           (.then (fn [kp]
+                    (js/Promise.all #js [(.exportKey (subtle) "spki" (.-publicKey kp))
+                                         (.exportKey (subtle) "pkcs8" (.-privateKey kp))])))
+           (.then (fn [arr]
+                    (a/put! ch {:public  (der->raw (js/Uint8Array. (aget arr 0)))
+                                :private (der->raw (js/Uint8Array. (aget arr 1)))})
+                    (a/close! ch))
+                  (fn [err] (a/put! ch (ex-info "X25519 keygen failed" {:error err})) (a/close! ch))))
+       ch)))
+
+#?(:cljs
+   (defn- cljs-agree [scalar pub]
+     (let [ch (a/chan 1)]
+       (-> (js/Promise.all
+            #js [(.importKey (subtle) "pkcs8" (scalar->pkcs8 scalar) #js {:name "X25519"} false #js ["deriveBits"])
+                 (.importKey (subtle) "spki" (pub->spki pub) #js {:name "X25519"} false #js [])])
+           (.then (fn [ks]
+                    (.deriveBits (subtle) #js {:name "X25519" :public (aget ks 1)} (aget ks 0) 256)))
+           (.then (fn [buf] (a/put! ch (js/Uint8Array. buf)) (a/close! ch))
+                  (fn [err] (a/put! ch (ex-info "X25519 key agreement failed" {:error err})) (a/close! ch))))
+       ch)))
+
+(defn generate-keypair
+  "Generate a fresh X25519 keypair. -> channel of {:public <32 bytes>
+   :private <32-byte scalar>}."
+  []
+  #?(:clj (jvm->chan jvm-generate) :cljs (cljs-generate)))
+
+(defn key-agreement
+  "Derive the shared secret from your 32-byte `private-key` scalar and the peer's
+   32-byte `public-key`. -> channel of the 32-byte shared secret. Both peers get
+   the SAME secret from opposite halves. Do NOT use the raw output as a key —
+   feed it through `hkdf` to derive an AEAD key."
+  [private-key public-key]
+  #?(:clj  (jvm->chan #(jvm-agree private-key public-key))
+     :cljs (cljs-agree private-key public-key)))

--- a/test/org/replikativ/geheimnis/dh_test.cljc
+++ b/test/org/replikativ/geheimnis/dh_test.cljc
@@ -1,0 +1,63 @@
+(ns org.replikativ.geheimnis.dh-test
+  "X25519 key agreement round-trip + a fixed interop KAT. The two keypairs and
+   their shared secret were produced on the JVM; a CLJS/Node peer that derives
+   the SAME secret from either half is byte-compatible — two peers on different
+   platforms agree a key with no pre-shared secret. Both use their native X25519
+   (java.security / Web Crypto), so agreement here is a real correctness anchor."
+  (:require #?(:clj [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer-macros [deftest is testing async]])
+            [clojure.core.async :as a]
+            [org.replikativ.geheimnis.dh :as dh]
+            [org.replikativ.geheimnis.codec :as codec]))
+
+(def ^:private a-priv  "f30161b780294aa43a007352eec5f750ada316be85928b32e5b2a7cf0aa9f369")
+(def ^:private a-pub   "5e8bba745fb55760deff40ecc4832d72859599b463a2a033a9e17f18bda0e643")
+(def ^:private b-priv  "ced519ca9f4bec17448e42de1b11a4d1980aaf6046cb2d3a25029a9e87fae675")
+(def ^:private b-pub   "30c9b0cba4e38fda13b7166eea8e604e94cfb4322c55124c63a5945bad58c423")
+(def ^:private secret  "0e8bd4ae825a73f16f5dfa51388e79e5320a486639181d80ec33cdfe81416568")
+
+(defn- hex [r]
+  (if #?(:clj (bytes? r) :cljs (instance? js/Uint8Array r))
+    (codec/bytes->hex r)
+    ::error))
+
+(deftest x25519-interop-kat
+  (let [ap (codec/hex->bytes a-priv) au (codec/hex->bytes a-pub)
+        bp (codec/hex->bytes b-priv) bu (codec/hex->bytes b-pub)]
+    #?(:clj
+       (do
+         (is (= secret (hex (a/<!! (dh/key-agreement ap bu)))) "agree(a-priv, b-pub) -> fixed secret")
+         (is (= secret (hex (a/<!! (dh/key-agreement bp au)))) "agree(b-priv, a-pub) -> same secret"))
+       :cljs
+       (async
+        done
+        (a/go
+          (is (= secret (hex (a/<! (dh/key-agreement ap bu)))) "agree(a-priv, b-pub) -> fixed secret")
+          (is (= secret (hex (a/<! (dh/key-agreement bp au)))) "agree(b-priv, a-pub) -> same secret")
+          (done))))))
+
+(deftest x25519-roundtrip
+  #?(:clj
+     (let [{ap :private au :public} (a/<!! (dh/generate-keypair))
+           {bp :private bu :public} (a/<!! (dh/generate-keypair))
+           s-ab (a/<!! (dh/key-agreement ap bu))
+           s-ba (a/<!! (dh/key-agreement bp au))]
+       (testing "both halves derive the same 32-byte secret"
+         (is (= (hex s-ab) (hex s-ba)))
+         (is (= 32 (codec/blen s-ab))))
+       (testing "a different peer derives a different secret"
+         (let [{cp :private} (a/<!! (dh/generate-keypair))]
+           (is (not= (hex s-ab) (hex (a/<!! (dh/key-agreement cp au))))))))
+     :cljs
+     (async
+      done
+      (a/go
+        (let [{ap :private au :public} (a/<! (dh/generate-keypair))
+              {bp :private bu :public} (a/<! (dh/generate-keypair))
+              s-ab (a/<! (dh/key-agreement ap bu))
+              s-ba (a/<! (dh/key-agreement bp au))
+              {cp :private} (a/<! (dh/generate-keypair))]
+          (is (= (hex s-ab) (hex s-ba)) "both halves agree")
+          (is (= 32 (codec/blen s-ab)) "32-byte secret")
+          (is (not= (hex s-ab) (hex (a/<! (dh/key-agreement cp au)))) "wrong peer differs")
+          (done))))))


### PR DESCRIPTION
Adds `org.replikativ.geheimnis.dh` — X25519 key agreement — completing the v2 asymmetric tier (`sign` + `dh`).

## Why
The confidentiality counterpart to `sign`. Two peers derive the **same** 32-byte shared secret from opposite halves (their private key + the other's public key), with no pre-shared secret and nothing secret on the wire. This is how a sender establishes an encryption key with a recipient so a relay/server can carry **ciphertext it cannot read** — the primitive behind end-to-end encrypted, peer-replicated data (e.g. an encrypted knowledge base replicated between users without the server reading it).

## What
- `generate-keypair` / `key-agreement`, async on both platforms (uniform `core.async` channel, same shape as `sign`/`aead`). JVM: `java.security` + `javax.crypto KeyAgreement`. CLJS: Web Crypto `deriveBits` (Node 18+, modern browsers).
- Raw keys (32-byte public, 32-byte scalar, 32-byte secret), wrapped in PKCS#8/SPKI DER with the X25519 OID (`1.3.101.110`) so the same bytes move between `java.security` and Web Crypto unchanged.
- **Interop KAT**: two keypairs + their shared secret captured on the JVM; Node derives the identical secret from either half — byte-level JVM↔Node interop proven.

## Verified
JVM 14 tests / 34 assertions, Node 14 / 34, 0 failures.

## Usage
Never use the raw shared secret as a key — feed it through `hkdf` to derive an AEAD key, then `aead`. `dh` establishes the key, `hkdf` shapes it, `aead` uses it.

## Note
This lands the *primitive* only. The scheme that composes `dh`+`aead`+konserve into E2E-encrypted KBs (envelope format, keyring/multi-recipient, revocation, the konserve sync/async encryptor decision) is a separate, still-open design — captured internally, to be built alongside the konserve encryptor work.
