### PR TITLE
feat(aead): synchronous JVM tier (aead-encrypt-sync / aead-decrypt-sync)

### DIFF
--- a/src/org/replikativ/geheimnis/aead.cljc
+++ b/src/org/replikativ/geheimnis/aead.cljc
@@ -8,6 +8,12 @@
    on CLJS is Promise-based; the JVM resolves synchronously into the channel. The
    contract is identical on both platforms.
 
+   SYNC: `aead-encrypt-sync` / `aead-decrypt-sync` are JVM-only — `javax.crypto`
+   GCM is already synchronous, so the channel is pure ceremony there. On CLJS they
+   throw: Web Crypto has no synchronous surface, so a caller that needs sync AEAD
+   in the browser cannot be satisfied and should hear that rather than block.
+   Both tiers produce and consume the SAME bytes.
+
    Conventions: 256-bit key (32 bytes), 96-bit nonce (12 bytes), 128-bit tag
    appended to the ciphertext (both JVM `AES/GCM/NoPadding` and Web Crypto lay the
    tag out the same way, so JVM↔CLJS ciphertext is interoperable). `aad` (bytes or
@@ -74,3 +80,29 @@
   [key nonce aad ciphertext]
   #?(:clj  (jvm->chan #(jvm-gcm Cipher/DECRYPT_MODE key nonce aad ciphertext))
      :cljs (cljs-gcm "decrypt" key nonce aad ciphertext)))
+
+;; ---------------------------------------------------------------------------
+;; synchronous tier — JVM only
+;; ---------------------------------------------------------------------------
+
+#?(:cljs
+   (defn- no-sync [op]
+     (throw (ex-info (str "Synchronous AEAD (" op ") is not available on ClojureScript: "
+                          "Web Crypto exposes no synchronous cipher. Use aead-"
+                          op " (async) instead.")
+                     {:type :sync-aead-unavailable :platform :cljs :op op}))))
+
+(defn aead-encrypt-sync
+  "JVM-only synchronous `aead-encrypt`. -> (ciphertext ‖ 128-bit tag), throws on
+   failure. Byte-identical to the async tier. Throws on CLJS."
+  [key nonce aad plaintext]
+  #?(:clj  (jvm-gcm Cipher/ENCRYPT_MODE key nonce aad plaintext)
+     :cljs (no-sync "encrypt")))
+
+(defn aead-decrypt-sync
+  "JVM-only synchronous `aead-decrypt`. -> plaintext, or THROWS
+   `javax.crypto.AEADBadTagException` if the tag does not verify (tamper / wrong
+   key / wrong nonce / wrong aad). Throws on CLJS."
+  [key nonce aad ciphertext]
+  #?(:clj  (jvm-gcm Cipher/DECRYPT_MODE key nonce aad ciphertext)
+     :cljs (no-sync "decrypt")))

--- a/test/org/replikativ/geheimnis/aead_test.cljc
+++ b/test/org/replikativ/geheimnis/aead_test.cljc
@@ -72,3 +72,29 @@
           (is (= ::error (result-hex (a/<! (aead/aead-decrypt (gc/random-bytes 32) nonce aad ct)))) "wrong key")
           (is (= ::error (result-hex (a/<! (aead/aead-decrypt key nonce (codec/str->bytes "ctx:v2") ct)))) "wrong aad")
           (done))))))
+
+;; The sync tier exists so callers with a synchronous execution model (konserve's
+;; `{:sync? true}` stores) can use AEAD on the JVM. It must be byte-compatible
+;; with the async tier — the same store must be readable either way.
+#?(:clj
+   (deftest aead-sync-matches-async
+     (let [key (gc/random-bytes 32) nonce (gc/random-bytes 12)
+           aad (codec/str->bytes "ctx:v1") pt (codec/str->bytes "sync tier 🔐")]
+       (testing "sync encrypt produces the KAT bytes"
+         (is (= kat-ct (codec/bytes->hex
+                        (aead/aead-encrypt-sync (codec/hex->bytes kat-key)
+                                                (codec/hex->bytes kat-nonce)
+                                                (codec/str->bytes kat-aad)
+                                                (codec/str->bytes kat-pt))))))
+       (testing "sync decrypts what async encrypted, and vice versa"
+         (let [ct-async (a/<!! (aead/aead-encrypt key nonce aad pt))
+               ct-sync  (aead/aead-encrypt-sync key nonce aad pt)]
+           (is (= (codec/bytes->hex ct-async) (codec/bytes->hex ct-sync)))
+           (is (= (codec/bytes->hex pt) (codec/bytes->hex (aead/aead-decrypt-sync key nonce aad ct-async))))
+           (is (= (codec/bytes->hex pt) (result-hex (a/<!! (aead/aead-decrypt key nonce aad ct-sync)))))))
+       (testing "sync decrypt THROWS on a bad tag (it cannot return an error value)"
+         (let [ct (aead/aead-encrypt-sync key nonce aad pt)]
+           (is (thrown? javax.crypto.AEADBadTagException
+                        (aead/aead-decrypt-sync key nonce aad (flip-first ct))))
+           (is (thrown? javax.crypto.AEADBadTagException
+                        (aead/aead-decrypt-sync key nonce (codec/str->bytes "ctx:v2") ct))))))))


### PR DESCRIPTION
konserve's `{:sync? true}` stores have no channel to park on, so they cannot use the async AEAD tier at all — and on the JVM they shouldn't have to: `javax.crypto` GCM is already synchronous, and `jvm->chan` is just wrapping a synchronous call in a channel it immediately closes.

Exposes that call directly:

- `aead-encrypt-sync` / `aead-decrypt-sync` — JVM only. `aead-decrypt-sync` **throws** `AEADBadTagException` on a bad tag rather than returning an error value on a channel, which is the natural synchronous contract.
- On ClojureScript both throw a clear `ex-info`. Web Crypto exposes no synchronous cipher, so a caller who needs sync AEAD in the browser cannot be satisfied and should hear that rather than get a subtly broken fallback.

The two tiers are byte-identical, which the tests pin: the sync tier reproduces the existing interop KAT, and a cross-tier test decrypts async-produced ciphertext synchronously and vice versa.

Needed by replikativ/konserve#150, which adds an `:aes-gcm` encryptor and supports `{:sync? true}` stores on the JVM.

## Testing
`15 tests, 40 assertions, 0 failures` on the JVM; node build compiles clean; cljfmt clean.